### PR TITLE
Add python3-future to Build-Depends (install_requires)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
 annexremote (1.4.3-1) UNRELEASED; urgency=medium
 
+  [ Michael Hanke ]
   * Initial Debian packaging (Closes: #963593).
 
- -- Michael Hanke <mih@debian.org>  Wed, 24 Jun 2020 10:09:42 +0200
+  [ Yaroslav Halchenko ]
+  * Add python3-future to Build-Depends (install_requires)
+
+ -- Yaroslav Halchenko <debian@onerussian.com>  Thu, 16 Jul 2020 17:07:37 -0400

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Uploaders: Michael Hanke <mih@debian.org>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
                python3-all,
+               python3-future,
                python3-nose,
                python3-setuptools,
 Standards-Version: 4.5.0


### PR DESCRIPTION
This package did build, and I had uploaded it to neurodebian for wherever it did build:

```
annexremote_1.4.3-1_amd64.build	OK	1:50.13 real, 87.54 user, 35.87 sys, 606472 out
annexremote_1.4.3-1~nd80+1_amd64.build	FAILED	0:51.95 real, 38.27 user, 17.10 sys, 103104 out
annexremote_1.4.3-1~nd90+1_amd64.build	OK	1:27.99 real, 62.04 user, 31.57 sys, 491000 out
annexremote_1.4.3-1~nd100+1_amd64.build	OK	1:42.29 real, 82.87 user, 32.70 sys, 532328 out
annexremote_1.4.3-1~nd110+1_amd64.build	OK	1:47.92 real, 86.24 user, 36.08 sys, 540272 out
annexremote_1.4.3-1~nd+1_amd64.build	OK	1:50.01 real, 88.49 user, 36.66 sys, 569024 out
annexremote_1.4.3-1~nd14.04+1_amd64.build	FAILED	1:14.11 real, 54.84 user, 24.44 sys, 106032 out
annexremote_1.4.3-1~nd16.04+1_amd64.build	FAILED	1:10.07 real, 52.05 user, 23.45 sys, 117888 out
annexremote_1.4.3-1~nd18.04+1_amd64.build	OK	2:14.89 real, 102.93 user, 46.58 sys, 514968 out
annexremote_1.4.3-1~nd20.04+1_amd64.build	OK	2:21.37 real, 107.85 user, 48.21 sys, 564136 out

```

Following up on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=963593#10 -- you seems to be a member of DPMT for two weeks by now ;)

meanwhile - I will try to build datalad 0.13.0 on neurodebians and see how that goes